### PR TITLE
fix linkedhashmap.Map comment error

### DIFF
--- a/maps/linkedhashmap/linkedhashmap.go
+++ b/maps/linkedhashmap/linkedhashmap.go
@@ -22,7 +22,7 @@ func assertMapImplementation() {
 	var _ maps.Map = (*Map)(nil)
 }
 
-// Map holds the elements in a red-black tree
+// Map holds the elements in a regular hash table, and uses doubly-linked list to store key ordering.
 type Map struct {
 	table    map[interface{}]interface{}
 	ordering *doublylinkedlist.List


### PR DESCRIPTION
In linkedhashmap.go there is a line of comment saying "Map holds the elements in a red-black tree", which is not true. The linkedhashmap holds it's elements in a regular hash table, and uses doubly-linked list to store key ordering.